### PR TITLE
Redesign content rule to support all possible values

### DIFF
--- a/example/Test.re
+++ b/example/Test.re
@@ -1295,12 +1295,52 @@ let make = () =>
       </div>
     </Section>
     <Section name="content">
+      <div
+        className=Css.(
+          style([
+            position(relative),
+            after([
+              contentRule(`none),
+              position(absolute),
+              top(zero),
+              left(zero),
+              width(pct(100.)),
+              height(pct(100.)),
+              border(px(1), solid, black),
+            ]),
+          ])
+        )>
+        {text("none")}
+      </div>
+      <div
+        className=Css.(
+          style([
+            position(relative),
+            after([
+              contentRule(`normal),
+              position(absolute),
+              top(zero),
+              left(zero),
+              width(pct(100.)),
+              height(pct(100.)),
+              border(px(1), solid, black),
+            ]),
+          ])
+        )>
+        {text("normal")}
+      </div>
+      <div className=Css.(
+          style([
+            position(relative),
+            marginLeft(px(20)),
+          ])
+        )>
       <a
         href="https://github.com/SentiaAnalytics/bs-css"
         className=Css.(
           style([
             before([
-              contentRule("external "),
+              contentRule(`string("external ")),
               backgroundColor(red),
               display(inlineBlock),
               flexBasis(content /*for test*/),
@@ -1309,13 +1349,14 @@ let make = () =>
         )>
         {text("link")}
       </a>
+      </div>
       <div
         className=Css.(
           style([
             position(relative),
             marginLeft(px(20)),
             after([
-              contentRule(""),
+              contentRule(`string("")),
               position(absolute),
               top(zero),
               left(zero),
@@ -1326,6 +1367,99 @@ let make = () =>
           ])
         )>
         {text("empty content")}
+      </div>
+      <div
+        className=Css.(
+          style([
+            position(relative),
+            marginLeft(px(20)),
+            paddingLeft(px(20)),
+            after([
+              contentRule(`url("https://via.placeholder.com/18")),
+              position(absolute),
+              top(zero),
+              left(zero),
+              width(px(18)),
+              height(px(18)),
+              border(px(1), solid, black),
+            ]),
+          ])
+        )>
+        {text("url")}
+      </div>
+      <div
+        className=Css.(
+          style([
+            marginLeft(px(20)),
+            counterReset(Types.CounterOperation.reset("foo", ~value=1)),
+            before([
+              contentRule(Types.Counter.counter("foo")),
+              border(px(1), solid, black),
+            ]),
+          ])
+        )>
+        {text("counter")}
+      </div>
+      <div className=Css.(
+            style([
+              counterReset(Types.CounterOperation.reset("foo", ~value=1)),
+              marginLeft(px(20))
+            ])
+      )>
+        <div
+          className=Css.(
+            style([
+              counterReset(Types.CounterOperation.reset("foo", ~value=2)),
+              before([
+                contentRule(Types.Counter.counters("foo", ~separator="@", ~style=`upperRoman)),
+                border(px(1), solid, black),
+              ]),
+            ])
+          )>
+          {text("counters")}
+        </div>
+      </div>
+      <div
+        className=Css.(
+          style([
+            marginLeft(px(20)),
+            before([
+              contentRule(`attr("class")),
+              border(px(1), solid, black),
+            ]),
+          ])
+        )>
+        {text("attr")}
+      </div>
+      <div
+        className=Css.(
+          style([
+            marginLeft(px(20)),
+            before([
+              contentRule(Types.Gradient.linearGradient(
+                  deg(45.),
+                  [(zero, red), (pct(100.), blue)],
+                )),
+              border(px(1), solid, black),
+              display(`inlineBlock),
+              height(px(18)),
+              width(px(18))
+            ]),
+          ])
+        )>
+        {text("linear gradient")}
+      </div>
+      <div
+        className=Css.(
+          style([
+            marginLeft(px(20)),
+            before([
+              contentRules([`openQuote, `string("foo"), `closeQuote]),
+              border(px(1), solid, black),
+            ]),
+          ])
+        )>
+        {text("contents (quotes)")}
       </div>
     </Section>
     <Section name="insertRule, the ultimate escape hatch">

--- a/example/Test.re
+++ b/example/Test.re
@@ -1340,7 +1340,7 @@ let make = () =>
         className=Css.(
           style([
             before([
-              contentRule(`string("external ")),
+              contentRule(`text("external ")),
               backgroundColor(red),
               display(inlineBlock),
               flexBasis(content /*for test*/),
@@ -1356,7 +1356,7 @@ let make = () =>
             position(relative),
             marginLeft(px(20)),
             after([
-              contentRule(`string("")),
+              contentRule(`text("")),
               position(absolute),
               top(zero),
               left(zero),
@@ -1454,7 +1454,7 @@ let make = () =>
           style([
             marginLeft(px(20)),
             before([
-              contentRules([`openQuote, `string("foo"), `closeQuote]),
+              contentRules([`openQuote, `text("foo"), `closeQuote]),
               border(px(1), solid, black),
             ]),
           ])

--- a/example/Test.re
+++ b/example/Test.re
@@ -1391,7 +1391,7 @@ let make = () =>
         className=Css.(
           style([
             marginLeft(px(20)),
-            counterReset(Types.CounterOperation.reset("foo", ~value=1)),
+            counterReset(Types.CounterReset.reset("foo", ~value=1)),
             before([
               contentRule(Types.Counter.counter("foo")),
               border(px(1), solid, black),
@@ -1402,14 +1402,14 @@ let make = () =>
       </div>
       <div className=Css.(
             style([
-              counterReset(Types.CounterOperation.reset("foo", ~value=1)),
+              counterReset(Types.CounterReset.reset("foo", ~value=1)),
               marginLeft(px(20))
             ])
       )>
         <div
           className=Css.(
             style([
-              counterReset(Types.CounterOperation.reset("foo", ~value=2)),
+              counterReset(Types.CounterReset.reset("foo", ~value=2)),
               before([
                 contentRule(Types.Counter.counters("foo", ~separator="@", ~style=`upperRoman)),
                 border(px(1), solid, black),

--- a/example/Test.re
+++ b/example/Test.re
@@ -1411,7 +1411,7 @@ let make = () =>
             style([
               counterReset(Types.CounterReset.reset("foo", ~value=2)),
               before([
-                contentRule(Types.Counter.counters("foo", ~separator="@", ~style=`upperRoman)),
+                contentRule(Types.Counters.counters("foo", ~separator="@", ~style=`upperRoman)),
                 border(px(1), solid, black),
               ]),
             ])

--- a/src/Css.re
+++ b/src/Css.re
@@ -168,6 +168,7 @@ module Converter = {
     switch (x) {
     | #Content.t as c => Content.toString(c)
     | #Counter.t as c => Counter.toString(c)
+    | #Counters.t as c => Counters.toString(c)
     | #Gradient.t as g => Gradient.toString(g)
     | #Url.t as u => Url.toString(u)
     | #Cascading.t as c => Cascading.toString(c)

--- a/src/Css.re
+++ b/src/Css.re
@@ -167,6 +167,7 @@ module Converter = {
   let string_of_content = x =>
     switch (x) {
     | #Content.t as c => Content.toString(c)
+    | #Counter.t as c => Counter.toString(c)
     | #Gradient.t as g => Gradient.toString(g)
     | #Url.t as u => Url.toString(u)
     | #Cascading.t as c => Cascading.toString(c)

--- a/src/Css.re
+++ b/src/Css.re
@@ -172,9 +172,19 @@ module Converter = {
     | #Url.t as u => Url.toString(u)
     | #Cascading.t as c => Cascading.toString(c)
     };
-  let string_of_counter_operation = x =>
+  let string_of_counter_increment = x =>
     switch (x) {
-    | #CounterOperation.t as o => CounterOperation.toString(o)
+    | #CounterIncrement.t as o => CounterIncrement.toString(o)
+    | #Cascading.t as c => Cascading.toString(c)
+    };
+  let string_of_counter_reset = x =>
+    switch (x) {
+    | #CounterReset.t as o => CounterReset.toString(o)
+    | #Cascading.t as c => Cascading.toString(c)
+    };
+  let string_of_counter_set = x =>
+    switch (x) {
+    | #CounterSet.t as o => CounterSet.toString(o)
     | #Cascading.t as c => Cascading.toString(c)
     };
 };
@@ -448,25 +458,25 @@ let contentRules = xs =>
   D("content", xs->Belt.List.map(string_of_content)->join(" "));
 
 let counterIncrement = x =>
-  D("counter-increment", string_of_counter_operation(x));
+  D("counter-increment", string_of_counter_increment(x));
 let countersIncrement = xs =>
   D(
     "counter-increment",
-    xs->Belt.List.map(string_of_counter_operation)->join(" "),
+    xs->Belt.List.map(string_of_counter_increment)->join(" "),
   );
 
-let counterReset = x => D("counter-reset", string_of_counter_operation(x));
+let counterReset = x => D("counter-reset", string_of_counter_reset(x));
 let countersReset = xs =>
   D(
     "counter-reset",
-    xs->Belt.List.map(string_of_counter_operation)->join(" "),
+    xs->Belt.List.map(string_of_counter_reset)->join(" "),
   );
 
-let counterSet = x => D("counter-set", string_of_counter_operation(x));
+let counterSet = x => D("counter-set", string_of_counter_set(x));
 let countersSet = xs =>
   D(
     "counter-set",
-    xs->Belt.List.map(string_of_counter_operation)->join(" "),
+    xs->Belt.List.map(string_of_counter_set)->join(" "),
   );
 
 let cursor = x => D("cursor", Cursor.toString(x));

--- a/src/Css.re
+++ b/src/Css.re
@@ -167,7 +167,6 @@ module Converter = {
   let string_of_content = x =>
     switch (x) {
     | #Content.t as c => Content.toString(c)
-    | #Counter.t as c => Counter.toString(c)
     | #Gradient.t as g => Gradient.toString(g)
     | #Url.t as u => Url.toString(u)
     | #Cascading.t as c => Cascading.toString(c)

--- a/src/Css.re
+++ b/src/Css.re
@@ -163,7 +163,22 @@ module Converter = {
     | `repeatingRadialGradient(stops) =>
       "repeating-radial-gradient(" ++ string_of_stops(stops) ++ ")"
     };
+
+  let string_of_content = x =>
+    switch (x) {
+    | #Content.t as c => Content.toString(c)
+    | #Counter.t as c => Counter.toString(c)
+    | #Gradient.t as g => Gradient.toString(g)
+    | #Url.t as u => Url.toString(u)
+    | #Cascading.t as c => Cascading.toString(c)
+    };
+  let string_of_counter_operation = x =>
+    switch (x) {
+    | #CounterOperation.t as o => CounterOperation.toString(o)
+    | #Cascading.t as c => Cascading.toString(c)
+    };
 };
+
 include Converter;
 
 let empty = [];
@@ -428,7 +443,31 @@ let columnCount = x =>
     },
   );
 
-let contentRule = x => D("content", {j|"$x"|j});
+let contentRule = x => D("content", string_of_content(x));
+let contentRules = xs =>
+  D("content", xs->Belt.List.map(string_of_content)->join(" "));
+
+let counterIncrement = x =>
+  D("counter-increment", string_of_counter_operation(x));
+let countersIncrement = xs =>
+  D(
+    "counter-increment",
+    xs->Belt.List.map(string_of_counter_operation)->join(" "),
+  );
+
+let counterReset = x => D("counter-reset", string_of_counter_operation(x));
+let countersReset = xs =>
+  D(
+    "counter-reset",
+    xs->Belt.List.map(string_of_counter_operation)->join(" "),
+  );
+
+let counterSet = x => D("counter-set", string_of_counter_operation(x));
+let countersSet = xs =>
+  D(
+    "counter-set",
+    xs->Belt.List.map(string_of_counter_operation)->join(" "),
+  );
 
 let cursor = x => D("cursor", Cursor.toString(x));
 

--- a/src/Css.rei
+++ b/src/Css.rei
@@ -357,9 +357,23 @@ let color: Types.Color.t => rule;
  */
 let columnCount: [< Types.ColumnCount.t | Types.Cascading.t] => rule;
 
-let contentRule: [< Types.Content.t | Types.Counter.t | Types.Gradient.t | Types.Url.t | Types.Cascading.t] => rule;
+let contentRule:
+  [<
+    Types.Content.t
+    | Types.Counter.t
+    | Types.Counters.t
+    | Types.Gradient.t
+    | Types.Url.t
+    | Types.Cascading.t
+  ] => rule;
 let contentRules:
-  list([< Types.Content.t | Types.Counter.t | Types.Gradient.t | Types.Url.t]) => rule;
+  list([<
+    Types.Content.t
+    | Types.Counter.t
+    | Types.Counters.t
+    | Types.Gradient.t
+    | Types.Url.t
+  ]) => rule;
 
 let counterIncrement: [< Types.CounterIncrement.t | Types.Cascading.t] => rule;
 let countersIncrement: list([< Types.CounterIncrement.t]) => rule;

--- a/src/Css.rei
+++ b/src/Css.rei
@@ -359,14 +359,14 @@ let columnCount: [< Types.ColumnCount.t | Types.Cascading.t] => rule;
 
 let contentRule: [< Types.Content.t | Types.Counter.t | Types.Gradient.t | Types.Url.t | Types.Cascading.t] => rule;
 let contentRules:
-  list([< Types.Content.t | Types.Counter.t | Types.Gradient.t | Types.Url.t | Types.Cascading.t]) => rule;
+  list([< Types.Content.t | Types.Counter.t | Types.Gradient.t | Types.Url.t]) => rule;
 
 let counterIncrement: [< Types.CounterOperation.t | Types.Cascading.t] => rule;
-let countersIncrement: list([< Types.CounterOperation.t | Types.Cascading.t]) => rule;
+let countersIncrement: list([< Types.CounterOperation.t]) => rule;
 let counterReset: [< Types.CounterOperation.t | Types.Cascading.t] => rule;
-let countersReset: list([< Types.CounterOperation.t | Types.Cascading.t]) => rule;
+let countersReset: list([< Types.CounterOperation.t]) => rule;
 let counterSet: [< Types.CounterOperation.t | Types.Cascading.t] => rule;
-let countersSet: list([< Types.CounterOperation.t | Types.Cascading.t]) => rule;
+let countersSet: list([< Types.CounterOperation.t]) => rule;
 
 let cursor: Types.Cursor.t => rule;
 

--- a/src/Css.rei
+++ b/src/Css.rei
@@ -357,7 +357,16 @@ let color: Types.Color.t => rule;
  */
 let columnCount: [< Types.ColumnCount.t | Types.Cascading.t] => rule;
 
-let contentRule: string => rule;
+let contentRule: [< Types.Content.t | Types.Counter.t | Types.Gradient.t | Types.Url.t | Types.Cascading.t] => rule;
+let contentRules:
+  list([< Types.Content.t | Types.Counter.t | Types.Gradient.t | Types.Url.t | Types.Cascading.t]) => rule;
+
+let counterIncrement: [< Types.CounterOperation.t | Types.Cascading.t] => rule;
+let countersIncrement: list([< Types.CounterOperation.t | Types.Cascading.t]) => rule;
+let counterReset: [< Types.CounterOperation.t | Types.Cascading.t] => rule;
+let countersReset: list([< Types.CounterOperation.t | Types.Cascading.t]) => rule;
+let counterSet: [< Types.CounterOperation.t | Types.Cascading.t] => rule;
+let countersSet: list([< Types.CounterOperation.t | Types.Cascading.t]) => rule;
 
 let cursor: Types.Cursor.t => rule;
 

--- a/src/Css.rei
+++ b/src/Css.rei
@@ -361,12 +361,12 @@ let contentRule: [< Types.Content.t | Types.Counter.t | Types.Gradient.t | Types
 let contentRules:
   list([< Types.Content.t | Types.Counter.t | Types.Gradient.t | Types.Url.t]) => rule;
 
-let counterIncrement: [< Types.CounterOperation.t | Types.Cascading.t] => rule;
-let countersIncrement: list([< Types.CounterOperation.t]) => rule;
-let counterReset: [< Types.CounterOperation.t | Types.Cascading.t] => rule;
-let countersReset: list([< Types.CounterOperation.t]) => rule;
-let counterSet: [< Types.CounterOperation.t | Types.Cascading.t] => rule;
-let countersSet: list([< Types.CounterOperation.t]) => rule;
+let counterIncrement: [< Types.CounterIncrement.t | Types.Cascading.t] => rule;
+let countersIncrement: list([< Types.CounterIncrement.t]) => rule;
+let counterReset: [< Types.CounterReset.t | Types.Cascading.t] => rule;
+let countersReset: list([< Types.CounterReset.t]) => rule;
+let counterSet: [< Types.CounterSet.t | Types.Cascading.t] => rule;
+let countersSet: list([< Types.CounterSet.t]) => rule;
 
 let cursor: Types.Cursor.t => rule;
 

--- a/src/Css_AtomicTypes.re
+++ b/src/Css_AtomicTypes.re
@@ -1572,3 +1572,77 @@ module FontDisplay = {
     | `fallback => "fallback"
     | `optional => "optional";
 };
+
+module Counter = {
+  type style = [ ListStyleType.t | `unset];
+  type t = [ | `counter(string, style) | `counters(string, string, style)];
+
+  let counter = (~style=`unset, name) => `counter((name, style));
+  let counters = (~style=`unset, ~separator="", name) =>
+    `counters((name, separator, style));
+
+  let toString =
+    fun
+    | `counter(counter, style) =>
+      switch (style) {
+      | `unset => "counter(" ++ counter ++ ")"
+      | #ListStyleType.t as t =>
+        "counter(" ++ counter ++ "," ++ ListStyleType.toString(t) ++ ")"
+      }
+    | `counters(counter, string, style) =>
+      switch (style) {
+      | `unset => "counters(" ++ counter ++ ",\"" ++ string ++ "\")"
+      | #ListStyleType.t as t =>
+        "counters("
+        ++ counter
+        ++ ",\""
+        ++ string
+        ++ "\","
+        ++ ListStyleType.toString(t)
+        ++ ")"
+      };
+};
+
+module CounterOperation = {
+  type t = [
+    | `none
+    | `increment(string, int)
+    | `reset(string, int)
+    | `set(string, int)
+  ];
+
+  let increment = (~value=1, name) => `increment((name, value));
+  let reset = (~value=0, name) => `reset((name, value));
+  let set = (~value=0, name) => `set((name, value));
+
+  let toString =
+    fun
+    | `none => "none"
+    | `increment(name, value) => name ++ " " ++ string_of_int(value)
+    | `reset(name, value) => name ++ " " ++ string_of_int(value)
+    | `set(name, value) => name ++ " " ++ string_of_int(value);
+};
+
+module Content = {
+  type t = [
+    | `none
+    | `normal
+    | `openQuote
+    | `closeQuote
+    | `noOpenQuote
+    | `noCloseQuote
+    | `attr(string)
+    | `string(string)
+  ];
+
+  let toString =
+    fun
+    | `none => "none"
+    | `normal => "normal"
+    | `openQuote => "open-quote"
+    | `closeQuote => "close-quote"
+    | `noOpenQuote => "no-open-quote"
+    | `noCloseQuote => "no-close-quote"
+    | `attr(name) => "attr(" ++ name ++ ")"
+    | `string(string) => {j|"$string"|j};
+};

--- a/src/Css_AtomicTypes.re
+++ b/src/Css_AtomicTypes.re
@@ -1603,23 +1603,36 @@ module Counter = {
       };
 };
 
-module CounterOperation = {
-  type t = [
-    | `none
-    | `increment(string, int)
-    | `reset(string, int)
-    | `set(string, int)
-  ];
+module CounterIncrement = {
+  type t = [ | `none | `increment(string, int) ];
 
   let increment = (~value=1, name) => `increment((name, value));
+
+  let toString =
+    fun
+    | `none => "none"
+    | `increment(name, value) => name ++ " " ++ string_of_int(value);
+};
+
+module CounterReset = {
+  type t = [ | `none | `reset(string, int) ];
+
   let reset = (~value=0, name) => `reset((name, value));
+
+  let toString =
+    fun
+    | `none => "none"
+    | `reset(name, value) => name ++ " " ++ string_of_int(value);
+};
+
+module CounterSet = {
+  type t = [ | `none | `set(string, int) ];
+
   let set = (~value=0, name) => `set((name, value));
 
   let toString =
     fun
     | `none => "none"
-    | `increment(name, value) => name ++ " " ++ string_of_int(value)
-    | `reset(name, value) => name ++ " " ++ string_of_int(value)
     | `set(name, value) => name ++ " " ++ string_of_int(value);
 };
 

--- a/src/Css_AtomicTypes.re
+++ b/src/Css_AtomicTypes.re
@@ -1632,7 +1632,7 @@ module Content = {
     | `noOpenQuote
     | `noCloseQuote
     | `attr(string)
-    | `string(string)
+    | `text(string)
   ];
 
   let toString =
@@ -1644,5 +1644,5 @@ module Content = {
     | `noOpenQuote => "no-open-quote"
     | `noCloseQuote => "no-close-quote"
     | `attr(name) => "attr(" ++ name ++ ")"
-    | `string(string) => {j|"$string"|j};
+    | `text(string) => {j|"$string"|j};
 };

--- a/src/Css_AtomicTypes.re
+++ b/src/Css_AtomicTypes.re
@@ -1573,8 +1573,16 @@ module FontDisplay = {
     | `optional => "optional";
 };
 
+module CounterStyleType = {
+  type t = [ ListStyleType.t ];
+
+  let toString =
+    fun
+    | #ListStyleType.t as c => ListStyleType.toString(c);
+};
+
 module Counter = {
-  type style = [ ListStyleType.t | `unset];
+  type style = [ CounterStyleType.t | `unset];
   type t = [ | `counter(string, style)];
 
   let counter = (~style=`unset, name) => `counter((name, style));
@@ -1584,13 +1592,13 @@ module Counter = {
     | `counter(counter, style) =>
       switch (style) {
       | `unset => "counter(" ++ counter ++ ")"
-      | #ListStyleType.t as t =>
-        "counter(" ++ counter ++ "," ++ ListStyleType.toString(t) ++ ")"
+      | #CounterStyleType.t as t =>
+        "counter(" ++ counter ++ "," ++ CounterStyleType.toString(t) ++ ")"
       };
 };
 
 module Counters = {
-  type style = [ ListStyleType.t | `unset];
+  type style = [ CounterStyleType.t | `unset];
   type t = [ | `counters(string, string, style)];
 
   let counters = (~style=`unset, ~separator="", name) =>
@@ -1601,13 +1609,13 @@ module Counters = {
     | `counters(name, separator, style) =>
       switch (style) {
       | `unset => "counters(" ++ name ++ ",\"" ++ separator ++ "\")"
-      | #ListStyleType.t as s =>
+      | #CounterStyleType.t as s =>
         "counters("
         ++ name
         ++ ",\""
         ++ separator
         ++ "\","
-        ++ ListStyleType.toString(s)
+        ++ CounterStyleType.toString(s)
         ++ ")"
       };
 };

--- a/src/Css_AtomicTypes.re
+++ b/src/Css_AtomicTypes.re
@@ -1575,11 +1575,9 @@ module FontDisplay = {
 
 module Counter = {
   type style = [ ListStyleType.t | `unset];
-  type t = [ | `counter(string, style) | `counters(string, string, style)];
+  type t = [ | `counter(string, style)];
 
   let counter = (~style=`unset, name) => `counter((name, style));
-  let counters = (~style=`unset, ~separator="", name) =>
-    `counters((name, separator, style));
 
   let toString =
     fun
@@ -1588,17 +1586,28 @@ module Counter = {
       | `unset => "counter(" ++ counter ++ ")"
       | #ListStyleType.t as t =>
         "counter(" ++ counter ++ "," ++ ListStyleType.toString(t) ++ ")"
-      }
-    | `counters(counter, string, style) =>
+      };
+};
+
+module Counters = {
+  type style = [ ListStyleType.t | `unset];
+  type t = [ | `counters(string, string, style)];
+
+  let counters = (~style=`unset, ~separator="", name) =>
+    `counters((name, separator, style));
+
+  let toString =
+    fun
+    | `counters(name, separator, style) =>
       switch (style) {
-      | `unset => "counters(" ++ counter ++ ",\"" ++ string ++ "\")"
-      | #ListStyleType.t as t =>
+      | `unset => "counters(" ++ name ++ ",\"" ++ separator ++ "\")"
+      | #ListStyleType.t as s =>
         "counters("
-        ++ counter
+        ++ name
         ++ ",\""
-        ++ string
+        ++ separator
         ++ "\","
-        ++ ListStyleType.toString(t)
+        ++ ListStyleType.toString(s)
         ++ ")"
       };
 };

--- a/src/Css_AtomicTypes.rei
+++ b/src/Css_AtomicTypes.rei
@@ -1164,10 +1164,19 @@ module FontDisplay: {
 };
 
 /**
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/counters
+ */
+module CounterStyleType: {
+  type t = [ ListStyleType.t];
+
+  let toString: t => string;
+};
+
+/**
  * https://developer.mozilla.org/en-US/docs/Web/CSS/counter
  */
 module Counter: {
-  type style = [ ListStyleType.t | `unset];
+  type style = [ CounterStyleType.t | `unset];
   type t = [ | `counter(string, style)];
 
   let counter: (~style: style=?, string) => t;
@@ -1179,7 +1188,7 @@ module Counter: {
  * https://developer.mozilla.org/en-US/docs/Web/CSS/counters
  */
 module Counters: {
-  type style = [ ListStyleType.t | `unset];
+  type style = [ CounterStyleType.t | `unset];
   type t = [ | `counters(string, string, style)];
 
   let counters: (~style: style=?, ~separator: string=?, string) => t;

--- a/src/Css_AtomicTypes.rei
+++ b/src/Css_AtomicTypes.rei
@@ -1162,3 +1162,50 @@ module FontDisplay: {
 
   let toString: t => string;
 };
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/counter
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/counters
+ */
+module Counter: {
+  type style = [ ListStyleType.t | `unset];
+  type t = [ | `counter(string, style) | `counters(string, string, style)];
+
+  let counter: (~style: style=?, string) => t;
+  let counters: (~style: style=?, ~separator: string=?, string) => t;
+
+  let toString: t => string;
+};
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/counter-increment
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/counter-reset
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/counter-set
+ */
+module CounterOperation: {
+  type t = [ | `none | `increment(string, int) | `reset(string, int) | `set(string, int)];
+
+  let increment: (~value: int=?, string) => t;
+  let reset: (~value: int=?, string) => t;
+  let set: (~value: int=?, string) => t;
+
+  let toString: t => string;
+};
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/content
+ */
+module Content: {
+  type t = [
+    | `none
+    | `normal
+    | `openQuote
+    | `closeQuote
+    | `noOpenQuote
+    | `noCloseQuote
+    | `attr(string)
+    | `string(string)
+  ];
+
+  let toString: t => string;
+};

--- a/src/Css_AtomicTypes.rei
+++ b/src/Css_AtomicTypes.rei
@@ -1165,13 +1165,23 @@ module FontDisplay: {
 
 /**
  * https://developer.mozilla.org/en-US/docs/Web/CSS/counter
- * https://developer.mozilla.org/en-US/docs/Web/CSS/counters
  */
 module Counter: {
   type style = [ ListStyleType.t | `unset];
-  type t = [ | `counter(string, style) | `counters(string, string, style)];
+  type t = [ | `counter(string, style)];
 
   let counter: (~style: style=?, string) => t;
+
+  let toString: t => string;
+};
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/counters
+ */
+module Counters: {
+  type style = [ ListStyleType.t | `unset];
+  type t = [ | `counters(string, string, style)];
+
   let counters: (~style: style=?, ~separator: string=?, string) => t;
 
   let toString: t => string;

--- a/src/Css_AtomicTypes.rei
+++ b/src/Css_AtomicTypes.rei
@@ -1179,14 +1179,32 @@ module Counter: {
 
 /**
  * https://developer.mozilla.org/en-US/docs/Web/CSS/counter-increment
- * https://developer.mozilla.org/en-US/docs/Web/CSS/counter-reset
- * https://developer.mozilla.org/en-US/docs/Web/CSS/counter-set
  */
-module CounterOperation: {
-  type t = [ | `none | `increment(string, int) | `reset(string, int) | `set(string, int)];
+module CounterIncrement: {
+  type t = [ | `none | `increment(string, int)];
 
   let increment: (~value: int=?, string) => t;
+
+  let toString: t => string;
+};
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/counter-reset
+ */
+module CounterReset: {
+  type t = [ | `none | `reset(string, int)];
+
   let reset: (~value: int=?, string) => t;
+
+  let toString: t => string;
+};
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/counter-set
+ */
+module CounterSet: {
+  type t = [ | `none | `set(string, int)];
+
   let set: (~value: int=?, string) => t;
 
   let toString: t => string;

--- a/src/Css_AtomicTypes.rei
+++ b/src/Css_AtomicTypes.rei
@@ -1204,7 +1204,7 @@ module Content: {
     | `noOpenQuote
     | `noCloseQuote
     | `attr(string)
-    | `string(string)
+    | `text(string)
   ];
 
   let toString: t => string;


### PR DESCRIPTION
It's, unfortunately, a breaking change. To support values other than strings, I had to introduce variant type, so existing rules need to be migrated like this:

```diff
-  contentRule("foo")
+  contentRule(`string("foo"))
```
Do you think that's okay? Can we afford another major version in such a short time? Maybe there is another way to model this?

If we eventually agree to break the API, does it make sense to rename `contentRule` to `content`? (and `contentRules` to `contents` I suppose). I was quite surprised that `content` function is not available, but I assume there was a good reason for this name. What was that?

Plus, I've added support for `counter-*` rules and matching functions.