### PR TITLE
[example] Property with unitless value

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ module Styles = {
 
   let title = style([
     fontSize(rem(1.5)),
+    lineHeight(`abs(1.25)),
     color(Theme.textColor),
     marginBottom(Theme.basePadding)
   ]);


### PR DESCRIPTION
I think is interesting to have an example of how to use unitless values with `bs-css` :+1: 