### PR TITLE
[README.md] Add end tag to button element

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ module Styles = {
 
 <div className=Styles.card>
   <h1 className=Styles.title> (ReasonReact.stringToElement("Hello")) </h1>
-  <button className=Styles.actionButton(false)>
+  <button className=Styles.actionButton(false) />
 </div>
 ```
 
@@ -245,7 +245,7 @@ module Styles = {
 
 <div style=Styles.card>
   <h1 style=Styles.title> (ReasonReact.stringToElement("Hello")) </h1>
-  <button style=Styles.actionButton(false)>
+  <button style=Styles.actionButton(false) />
 </div>
 ```
 


### PR DESCRIPTION
I tried to run the `README.md` examples and I believe it is missing the end tag to `button` elements
