### PR TITLE
Support auto in `trackLength`

### DIFF
--- a/bs-css/__tests__/Css_test.re
+++ b/bs-css/__tests__/Css_test.re
@@ -608,6 +608,42 @@ describe("GridArea", () => {
   );
 });
 
+describe("gridTemplateCoumns", () => {
+  test("concatenates list", () =>
+    expect(
+      (
+        r(gridTemplateColumns([`fr(1.), `px(100), `auto])),
+      )
+      ->Js.Json.stringifyAny,
+    )
+    |> toBeJson((
+         {"gridTemplateColumns": "1fr 100px auto"},
+       ))
+  );
+
+  test("unfolds repeats", () =>
+    expect(
+      (
+        r(gridTemplateColumns([`repeat(`num(4), `fr(1.))])),
+        r(gridTemplateColumns([`repeat(`num(4), `auto)])),
+        r(gridTemplateColumns([`repeat(`num(4), `minContent)])),
+        r(gridTemplateColumns([`repeat(`num(4), `maxContent)])),
+        r(gridTemplateColumns([`repeat(`num(4), `minmax(`px(100), `fr(1.)))])),
+        // r(gridTemplateColumns([`repeat(`num(4), `fitContent(`px(200)))])),
+      )
+      ->Js.Json.stringifyAny,
+    )
+    |> toBeJson((
+         {"gridTemplateColumns": "repeat(4, 1fr)"},
+         {"gridTemplateColumns": "repeat(4, auto)"},
+         {"gridTemplateColumns": "repeat(4, min-content)"},
+         {"gridTemplateColumns": "repeat(4, max-content)"},
+         {"gridTemplateColumns": "repeat(4, minmax(100px,1fr))"},
+        //  {"gridTemplateColumns": "repeat(4, fit-content(200px))"},
+       ))
+  );
+});
+
 describe("backgroundPosition", () => {
   test("test single values", () =>
     expect(

--- a/bs-css/src/Css_Js_Core.re
+++ b/bs-css/src/Css_Js_Core.re
@@ -1583,6 +1583,7 @@ type minmax = [ | `fr(float) | `minContent | `maxContent | `auto | Length.t];
 
 type trackLength = [
   Length.t
+  | `auto
   | `fr(float)
   | `minContent
   | `maxContent

--- a/bs-css/src/Css_Js_Core.rei
+++ b/bs-css/src/Css_Js_Core.rei
@@ -1753,6 +1753,7 @@ type minmax = [
 
 type trackLength = [
   Types.Length.t
+  | `auto
   | `fr(float)
   | `minContent
   | `maxContent

--- a/bs-css/src/Css_Legacy_Core.re
+++ b/bs-css/src/Css_Legacy_Core.re
@@ -1590,6 +1590,7 @@ type minmax = [ | `fr(float) | `minContent | `maxContent | `auto | Length.t];
 
 type trackLength = [
   Length.t
+  | `auto
   | `fr(float)
   | `minContent
   | `maxContent

--- a/bs-css/src/Css_Legacy_Core.rei
+++ b/bs-css/src/Css_Legacy_Core.rei
@@ -1754,6 +1754,7 @@ type minmax = [
 
 type trackLength = [
   Types.Length.t
+  | `auto
   | `fr(float)
   | `minContent
   | `maxContent


### PR DESCRIPTION
Adding missing support for `auto` keyword in `repeat` function used by grid-templates. Closes https://github.com/reasonml-labs/bs-css/issues/211

While looking into it, noticed that many other combinations are not allowed. For example, `repeat` function doesn't support [`fit-content` function](https://developer.mozilla.org/en-US/docs/Web/CSS/fit-content). Also, there is no way to specify columns/row ids: https://developer.mozilla.org/en-US/docs/Web/CSS/repeat

I can look into it later or in this PR it is preferred
