### PR TITLE
Support "auto" keyword for positional rules

### DIFF
--- a/bs-css/src/Css_Js_Core.re
+++ b/bs-css/src/Css_Js_Core.re
@@ -94,6 +94,13 @@ module Converter = {
     | #Length.t as l => Length.toString(l)
     | #Var.t as va => Var.toString(va)
     | #Cascading.t as c => Cascading.toString(c);
+
+  let string_of_position =
+    fun
+    | `auto => "auto"
+    | #Length.t as l => Length.toString(l)
+    | #Var.t as va => Var.toString(va)
+    | #Cascading.t as c => Cascading.toString(c)
 };
 
 include Converter;
@@ -325,15 +332,7 @@ let borderTopWidth = x => D("borderTopWidth", Length.toString(x));
 
 let borderWidth = x => D("borderWidth", Length.toString(x));
 
-let bottom = x =>
-  D(
-    "bottom",
-    switch (x) {
-    | #Length.t as l => Length.toString(l)
-    | #Var.t as va => Var.toString(va)
-    | #Cascading.t as c => Cascading.toString(c)
-    },
-  );
+let bottom = x => D("bottom", string_of_position(x));
 
 let boxSizing = x =>
   D(
@@ -606,15 +605,7 @@ let justifyContent = x =>
     },
   );
 
-let left = x =>
-  D(
-    "left",
-    switch (x) {
-    | #Length.t as l => Length.toString(l)
-    | #Var.t as va => Var.toString(va)
-    | #Cascading.t as c => Cascading.toString(c)
-    },
-  );
+let left = x => D("left", string_of_position(x));
 
 let letterSpacing = x =>
   D(
@@ -914,15 +905,7 @@ let resize = x =>
     },
   );
 
-let right = x =>
-  D(
-    "right",
-    switch (x) {
-    | #Length.t as l => Length.toString(l)
-    | #Var.t as va => Var.toString(va)
-    | #Cascading.t as c => Cascading.toString(c)
-    },
-  );
+let right = x => D("right", string_of_position(x));
 
 let tableLayout = x =>
   D(
@@ -1005,15 +988,7 @@ let textTransform = x =>
     },
   );
 
-let top = x =>
-  D(
-    "top",
-    switch (x) {
-    | #Length.t as l => Length.toString(l)
-    | #Var.t as va => Var.toString(va)
-    | #Cascading.t as c => Cascading.toString(c)
-    },
-  );
+let top = x => D("top", string_of_position(x));
 
 let transform = x => D("transform", Transform.toString(x));
 

--- a/bs-css/src/Css_Js_Core.rei
+++ b/bs-css/src/Css_Js_Core.rei
@@ -342,7 +342,7 @@ let borderTopWidth: Types.Length.t => rule;
 
 let borderWidth: Types.Length.t => rule;
 
-let bottom: [< Types.Length.t | Types.Var.t | Types.Cascading.t] => rule;
+let bottom: [< `auto | Types.Length.t | Types.Var.t | Types.Cascading.t] => rule;
 
 /**
  The box-sizing CSS property sets how the total width and height of an element is calculated.
@@ -661,7 +661,7 @@ let justifySelf:
   ] =>
   rule;
 
-let left: [< Types.Length.t | Types.Var.t | Types.Cascading.t] => rule;
+let left: [< `auto | Types.Length.t | Types.Var.t | Types.Cascading.t] => rule;
 
 /**
  The letter-spacing CSS property sets the spacing behavior between text characters
@@ -914,7 +914,7 @@ let position: [< Types.Position.t | Types.Var.t | Types.Cascading.t] => rule;
  */
 let resize: [< Types.Resize.t | Types.Var.t | Types.Cascading.t] => rule;
 
-let right: [< Types.Length.t | Types.Var.t | Types.Cascading.t] => rule;
+let right: [< `auto | Types.Length.t | Types.Var.t | Types.Cascading.t] => rule;
 
 /**
  The table-layout CSS property sets the algorithm used to lay out <table> cells, rows, and columns.
@@ -979,7 +979,7 @@ let textShadows: array([ Shadow.t(Shadow.text)]) => rule;
 let textTransform:
   [< Types.TextTransform.t | Types.Var.t | Types.Cascading.t] => rule;
 
-let top: [< Types.Length.t | Types.Var.t | Types.Cascading.t] => rule;
+let top: [< `auto | Types.Length.t | Types.Var.t | Types.Cascading.t] => rule;
 
 let transform: Types.Transform.t => rule;
 

--- a/bs-css/src/Css_Legacy_Core.re
+++ b/bs-css/src/Css_Legacy_Core.re
@@ -104,6 +104,13 @@ module Converter = {
     | #Length.t as l => Length.toString(l)
     | #Var.t as va => Var.toString(va)
     | #Cascading.t as c => Cascading.toString(c);
+
+  let string_of_position =
+    fun
+    | `auto => "auto"
+    | #Length.t as l => Length.toString(l)
+    | #Var.t as va => Var.toString(va)
+    | #Cascading.t as c => Cascading.toString(c)
 };
 
 include Converter;
@@ -335,15 +342,7 @@ let borderTopWidth = x => D("borderTopWidth", Length.toString(x));
 
 let borderWidth = x => D("borderWidth", Length.toString(x));
 
-let bottom = x =>
-  D(
-    "bottom",
-    switch (x) {
-    | #Length.t as l => Length.toString(l)
-    | #Var.t as va => Var.toString(va)
-    | #Cascading.t as c => Cascading.toString(c)
-    },
-  );
+let bottom = x => D("bottom", string_of_position(x));
 
 let boxSizing = x =>
   D(
@@ -613,15 +612,7 @@ let justifyContent = x =>
     },
   );
 
-let left = x =>
-  D(
-    "left",
-    switch (x) {
-    | #Length.t as l => Length.toString(l)
-    | #Var.t as va => Var.toString(va)
-    | #Cascading.t as c => Cascading.toString(c)
-    },
-  );
+let left = x => D("left", string_of_position(x));
 
 let letterSpacing = x =>
   D(
@@ -921,15 +912,7 @@ let resize = x =>
     },
   );
 
-let right = x =>
-  D(
-    "right",
-    switch (x) {
-    | #Length.t as l => Length.toString(l)
-    | #Var.t as va => Var.toString(va)
-    | #Cascading.t as c => Cascading.toString(c)
-    },
-  );
+let right = x => D("right", string_of_position(x));
 
 let tableLayout = x =>
   D(
@@ -1012,15 +995,7 @@ let textTransform = x =>
     },
   );
 
-let top = x =>
-  D(
-    "top",
-    switch (x) {
-    | #Length.t as l => Length.toString(l)
-    | #Var.t as va => Var.toString(va)
-    | #Cascading.t as c => Cascading.toString(c)
-    },
-  );
+let top = x => D("top", string_of_position(x));
 
 let transform = x => D("transform", Transform.toString(x));
 

--- a/bs-css/src/Css_Legacy_Core.rei
+++ b/bs-css/src/Css_Legacy_Core.rei
@@ -343,7 +343,7 @@ let borderTopWidth: Types.Length.t => rule;
 
 let borderWidth: Types.Length.t => rule;
 
-let bottom: [< Types.Length.t | Types.Var.t | Types.Cascading.t] => rule;
+let bottom: [< `auto | Types.Length.t | Types.Var.t | Types.Cascading.t] => rule;
 
 /**
  The box-sizing CSS property sets how the total width and height of an element is calculated.
@@ -662,7 +662,7 @@ let justifySelf:
   ] =>
   rule;
 
-let left: [< Types.Length.t | Types.Var.t | Types.Cascading.t] => rule;
+let left: [< `auto | Types.Length.t | Types.Var.t | Types.Cascading.t] => rule;
 
 /**
  The letter-spacing CSS property sets the spacing behavior between text characters
@@ -915,7 +915,7 @@ let position: [< Types.Position.t | Types.Var.t | Types.Cascading.t] => rule;
  */
 let resize: [< Types.Resize.t | Types.Var.t | Types.Cascading.t] => rule;
 
-let right: [< Types.Length.t | Types.Var.t | Types.Cascading.t] => rule;
+let right: [< `auto | Types.Length.t | Types.Var.t | Types.Cascading.t] => rule;
 
 /**
  The table-layout CSS property sets the algorithm used to lay out <table> cells, rows, and columns.
@@ -980,7 +980,7 @@ let textShadows: list([ Shadow.t(Shadow.text)]) => rule;
 let textTransform:
   [< Types.TextTransform.t | Types.Var.t | Types.Cascading.t] => rule;
 
-let top: [< Types.Length.t | Types.Var.t | Types.Cascading.t] => rule;
+let top: [< `auto | Types.Length.t | Types.Var.t | Types.Cascading.t] => rule;
 
 let transform: Types.Transform.t => rule;
 


### PR DESCRIPTION
Adds support of `auto` keyword for `top`/`right`/`bottom`/`left` rules as it was missing:
https://developer.mozilla.org/en-US/docs/Web/CSS/left#Values