### PR TITLE
Add justify-items support

### DIFF
--- a/bs-css/src/Css_AtomicTypes.re
+++ b/bs-css/src/Css_AtomicTypes.re
@@ -1004,11 +1004,13 @@ module OverflowAlignment = {
 };
 
 module BaselineAlignment = {
-  type t = [ | `baseline];
+  type t = [ | `baseline | `firstBaseline | `lastBaseline ];
 
   let toString =
     fun
-    | `baseline => "baseline";
+    | `baseline => "baseline"
+    | `firstBaseline => "first baseline"
+    | `lastBaseline=> "last baseline";
 };
 
 module NormalAlignment = {

--- a/bs-css/src/Css_AtomicTypes.re
+++ b/bs-css/src/Css_AtomicTypes.re
@@ -991,6 +991,18 @@ module PositionalAlignment = {
     | `right => "right";
 };
 
+module OverflowAlignment = {
+  type t = [
+    | `safe(PositionalAlignment.t)
+    | `unsafe(PositionalAlignment.t)
+  ];
+
+  let toString =
+    fun
+    | `safe(pa) => "safe " ++ PositionalAlignment.toString(pa)
+    | `unsafe(pa) => "unsafe " ++ PositionalAlignment.toString(pa)
+};
+
 module BaselineAlignment = {
   type t = [ | `baseline];
 

--- a/bs-css/src/Css_AtomicTypes.re
+++ b/bs-css/src/Css_AtomicTypes.re
@@ -1032,6 +1032,17 @@ module DistributedAlignment = {
     | `stretch => "stretch";
 };
 
+module LegacyAlignment = {
+  type t = [ | `legacy | `legacyRight | `legacyLeft | `legacyCenter];
+
+  let toString =
+    fun
+    | `legacy => "legacy"
+    | `legacyRight => "legacy right"
+    | `legacyLeft => "legacy left"
+    | `legacyCenter => "legacy center";
+};
+
 module TextAlign = {
   type t = [ | `left | `right | `center | `justify];
 

--- a/bs-css/src/Css_AtomicTypes.rei
+++ b/bs-css/src/Css_AtomicTypes.rei
@@ -733,6 +733,15 @@ module DistributedAlignment: {
 };
 
 /**
+ https://drafts.csswg.org/css-align-3/#propdef-justify-items
+ */
+module LegacyAlignment: {
+  type t = [ | `legacy | `legacyRight | `legacyLeft | `legacyCenter];
+
+  let toString: t => string;
+};
+
+/**
  https://developer.mozilla.org/docs/Web/CSS/text-align
  */
 module TextAlign: {

--- a/bs-css/src/Css_AtomicTypes.rei
+++ b/bs-css/src/Css_AtomicTypes.rei
@@ -694,6 +694,18 @@ module PositionalAlignment: {
 };
 
 /**
+ https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Alignment#Overflow_alignment
+ */
+module OverflowAlignment: {
+  type t = [
+    | `safe(PositionalAlignment.t)
+    | `unsafe(PositionalAlignment.t)
+  ];
+
+  let toString: t => string;
+};
+
+/**
  https://developer.mozilla.org/docs/Web/CSS/justify-self
  */
 module BaselineAlignment: {

--- a/bs-css/src/Css_AtomicTypes.rei
+++ b/bs-css/src/Css_AtomicTypes.rei
@@ -706,10 +706,10 @@ module OverflowAlignment: {
 };
 
 /**
- https://developer.mozilla.org/docs/Web/CSS/justify-self
+ https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Alignment#Baseline_alignment
  */
 module BaselineAlignment: {
-  type t = [ | `baseline];
+  type t = [ | `baseline | `firstBaseline | `lastBaseline ];
 
   let toString: t => string;
 };

--- a/bs-css/src/Css_Js_Core.re
+++ b/bs-css/src/Css_Js_Core.re
@@ -101,7 +101,7 @@ module Converter = {
     | #Length.t as l => Length.toString(l)
     | #Var.t as va => Var.toString(va)
     | #Cascading.t as c => Cascading.toString(c)
-  
+
   let string_of_color =
     fun
     | #Color.t as co => Color.toString(co)
@@ -598,6 +598,20 @@ let justifyContent = x =>
     | #PositionalAlignment.t as pa => PositionalAlignment.toString(pa)
     | #NormalAlignment.t as na => NormalAlignment.toString(na)
     | #DistributedAlignment.t as da => DistributedAlignment.toString(da)
+    | #Var.t as va => Var.toString(va)
+    | #Cascading.t as c => Cascading.toString(c)
+    },
+  );
+
+let justifyItems = x =>
+  D(
+    "justifyItems",
+    switch (x) {
+    | #PositionalAlignment.t as pa => PositionalAlignment.toString(pa)
+    | #NormalAlignment.t as na => NormalAlignment.toString(na)
+    | #BaselineAlignment.t as ba => BaselineAlignment.toString(ba)
+    | #OverflowAlignment.t as oa => OverflowAlignment.toString(oa)
+    | #LegacyAlignment.t as la => LegacyAlignment.toString(la)
     | #Var.t as va => Var.toString(va)
     | #Cascading.t as c => Cascading.toString(c)
     },

--- a/bs-css/src/Css_Js_Core.rei
+++ b/bs-css/src/Css_Js_Core.rei
@@ -649,6 +649,21 @@ let justifyContent:
   rule;
 
 /**
+ The CSS justify-items property defines the default justify-self for all items of the box, giving them all
+ a default way of justifying each box along the appropriate axis.
+ */
+let justifyItems:
+  [<
+    Types.PositionalAlignment.t
+    | Types.NormalAlignment.t
+    | Types.BaselineAlignment.t
+    | Types.OverflowAlignment.t
+    | Types.LegacyAlignment.t
+    | Types.Var.t
+    | Types.Cascading.t
+  ] => rule;
+
+/**
  The CSS justify-self property sets the way a box is justified inside its alignment container along the appropriate axis.
  */
 let justifySelf:

--- a/bs-css/src/Css_Legacy_Core.re
+++ b/bs-css/src/Css_Legacy_Core.re
@@ -610,6 +610,20 @@ let justifyContent = x =>
     },
   );
 
+let justifyItems = x =>
+  D(
+    "justifyItems",
+    switch (x) {
+    | #PositionalAlignment.t as pa => PositionalAlignment.toString(pa)
+    | #NormalAlignment.t as na => NormalAlignment.toString(na)
+    | #BaselineAlignment.t as ba => BaselineAlignment.toString(ba)
+    | #OverflowAlignment.t as oa => OverflowAlignment.toString(oa)
+    | #LegacyAlignment.t as la => LegacyAlignment.toString(la)
+    | #Var.t as va => Var.toString(va)
+    | #Cascading.t as c => Cascading.toString(c)
+    },
+  );
+
 let left = x => D("left", string_of_position(x));
 
 let letterSpacing = x =>

--- a/bs-css/src/Css_Legacy_Core.rei
+++ b/bs-css/src/Css_Legacy_Core.rei
@@ -650,6 +650,21 @@ let justifyContent:
   rule;
 
 /**
+ The CSS justify-items property defines the default justify-self for all items of the box, giving them all
+ a default way of justifying each box along the appropriate axis.
+ */
+let justifyItems:
+  [<
+    Types.PositionalAlignment.t
+    | Types.NormalAlignment.t
+    | Types.BaselineAlignment.t
+    | Types.OverflowAlignment.t
+    | Types.LegacyAlignment.t
+    | Types.Var.t
+    | Types.Cascading.t
+  ] => rule;
+
+/**
  The CSS justify-self property sets the way a box is justified inside its alignment container along the appropriate axis.
  */
 let justifySelf:


### PR DESCRIPTION
This PR adds support for `justify-items`: 
https://developer.mozilla.org/en-US/docs/Web/CSS/justify-items

Addresses https://github.com/reasonml-labs/bs-css/issues/212
