### PR TITLE
Extend keywords support for width

### DIFF
--- a/bs-css/src/Css_AtomicTypes.re
+++ b/bs-css/src/Css_AtomicTypes.re
@@ -1413,12 +1413,14 @@ module TextDecorationStyle = {
 };
 
 module Width = {
-  type t = [ | `auto | `fitContent];
+  type t = [ | `auto | `maxContent | `minContent | `fitContent(Percentage.t)];
 
   let toString =
     fun
     | `auto => "auto"
-    | `fitContent => "fit-content";
+    | `maxContent => "max-content"
+    | `minContent => "min-content"
+    | `fitContent(p) => Printf.sprintf("fit-content(%s)", Percentage.toString(p));
 };
 
 module MaxWidth = {

--- a/bs-css/src/Css_AtomicTypes.rei
+++ b/bs-css/src/Css_AtomicTypes.rei
@@ -1017,7 +1017,7 @@ module TextDecorationStyle: {
  https://developer.mozilla.org/docs/Web/CSS/width
  */
 module Width: {
-  type t = [ | `auto | `fitContent];
+  type t = [ | `auto | `maxContent | `minContent | `fitContent(Percentage.t)];
 
   let toString: t => string;
 };


### PR DESCRIPTION
This PR adds support for `max-content` and `min-content` keywords to `Width.t` and fixes definition of `fit-content` to match spec: 
https://www.w3.org/TR/css-sizing-3/#valdef-width-fit-content-length-percentage