### PR TITLE
Fix kebab-case error for stroke-dasharray

### DIFF
--- a/bs-css/__tests__/Svg_test.re
+++ b/bs-css/__tests__/Svg_test.re
@@ -53,11 +53,11 @@ describe("strokeDasharray", () => {
       ->Js.Json.stringifyAny,
     )
     |> toBeJson((
-         {"stroke-dasharray": "1px 2px 3px 4px"},
-         {"stroke-dasharray": "1% 2% 3% 4%"},
-         {"stroke-dasharray": "1px 2% 3px 4%"},
-         {"stroke-dasharray": "1% 2px 3% 4px"},
-         {"stroke-dasharray": "none"},
+         {"strokeDasharray": "1px 2px 3px 4px"},
+         {"strokeDasharray": "1% 2% 3% 4%"},
+         {"strokeDasharray": "1px 2% 3px 4%"},
+         {"strokeDasharray": "1% 2px 3% 4px"},
+         {"strokeDasharray": "none"},
        ))
   )
 })

--- a/bs-css/src/Css_Js_Core.re
+++ b/bs-css/src/Css_Js_Core.re
@@ -2100,7 +2100,7 @@ module SVG = {
     );
   let stroke = x => D("stroke", string_of_color(x));
   let strokeDasharray = x =>
-    D("stroke-dasharray",
+    D("strokeDasharray",
       switch x {
       | `none => "none"
       | `dasharray(a) => a->Belt.Array.map(string_of_dasharray)->join(" ")

--- a/bs-css/src/Css_Legacy_Core.re
+++ b/bs-css/src/Css_Legacy_Core.re
@@ -2107,7 +2107,7 @@ module SVG = {
     );
   let stroke = x => D("stroke", string_of_color(x));
   let strokeDasharray = x =>
-    D("stroke-dasharray",
+    D("strokeDasharray",
       switch x {
       | `none => "none"
       | `dasharray(a) => a->Belt.List.map(string_of_dasharray)->join(" ")


### PR DESCRIPTION
As per https://github.com/reasonml-labs/bs-css/issues/206#issuecomment-778660990, css properties must be in camel case